### PR TITLE
Use try_remove to avoid panic

### DIFF
--- a/src/amqp/amqp_cbs_link.rs
+++ b/src/amqp/amqp_cbs_link.rs
@@ -319,7 +319,7 @@ impl AmqpCbsLink {
             Command::RemoveAuthorizationRefresher(link_identifier) => {
                 let key = self.active_link_identifiers.remove(&link_identifier);
                 if let Some(key) = key {
-                    self.delay_queue.remove(&key);
+                    self.delay_queue.try_remove(&key);
                 }
             }
         }


### PR DESCRIPTION
It was panicking because `remove` from the `DelayQueue` would panic if the key is not found. This is changed to `try_remove` so that the recovery process can proceed without caring whether the key is found or not.