### PR TITLE
Fix mgmt recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.18.1
+
+1. Closes the old session and management link when recovering from a retryable error.
+
 ## 0.18.0
 
 1. Updated `azure_core` to `0.18.0`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azeventhubs"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 description = "An unofficial AMQP 1.0 rust client for Azure Event Hubs"
 readme = "README.md"

--- a/examples/read_iothub_builtin_endpoints.rs
+++ b/examples/read_iothub_builtin_endpoints.rs
@@ -24,7 +24,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::time::sleep(std::time::Duration::from_secs(2 * 60)).await;
 
     let options = ReadEventOptions::default();
-    let mut stream = consumer_client.read_events(false, options).await?;
+    let start_position = azeventhubs::consumer::EventPosition::latest();
+    // let mut stream = consumer_client.read_events(false, options).await?;
+    let mut stream = consumer_client.read_events_from_partition("0", start_position, options).await?;
 
     let mut counter = 0;
     while let Some(event) = stream.next().await {

--- a/examples/read_iothub_builtin_endpoints.rs
+++ b/examples/read_iothub_builtin_endpoints.rs
@@ -21,6 +21,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
+    tokio::time::sleep(std::time::Duration::from_secs(2 * 60)).await;
+
     let options = ReadEventOptions::default();
     let mut stream = consumer_client.read_events(false, options).await?;
 

--- a/src/amqp/amqp_client.rs
+++ b/src/amqp/amqp_client.rs
@@ -362,6 +362,8 @@ impl RecoverableTransport for AmqpClient {
             Sharable::None => {}
         }
 
+        log::debug!("Client recovered");
+
         Ok(())
     }
 }

--- a/src/amqp/amqp_client.rs
+++ b/src/amqp/amqp_client.rs
@@ -348,16 +348,16 @@ impl RecoverableTransport for AmqpClient {
     type RecoverError = RecoverTransportClientError;
 
     async fn recover(&mut self) -> Result<(), Self::RecoverError> {
+        log::debug!("Recovering client");
+
         self.connection_scope.recover().await?;
         match &mut self.management_link {
             Sharable::Owned(link) => {
-                // self.connection_scope.recover_management_link(link).await?
-                *link = self.connection_scope.open_management_link().await?;
+                link.recover(&mut self.connection_scope).await?;
             }
             Sharable::Shared(lock) => {
                 let mut link = lock.write().await;
-                // self.connection_scope.recover_management_link(&mut link).await?
-                *link = self.connection_scope.open_management_link().await?;
+                link.recover(&mut self.connection_scope).await?;
             }
             Sharable::None => {}
         }

--- a/src/amqp/amqp_connection_scope.rs
+++ b/src/amqp/amqp_connection_scope.rs
@@ -270,13 +270,10 @@ impl AmqpConnectionScope {
     ) -> Result<AmqpManagementLink, OpenMgmtLinkError> {
         self.create_management_link()
             .await
-            .map(|(_session_handle, client)| AmqpManagementLink {
-                _session_handle,
-                client,
-            })
+            .map(|(session, client)| AmqpManagementLink::new(session, client))
     }
 
-    async fn create_management_link(
+    pub(crate) async fn create_management_link(
         &mut self,
     ) -> Result<(SessionHandle<()>, MgmtClient), OpenMgmtLinkError> {
         if self.is_disposed.load(Ordering::Relaxed) {

--- a/src/amqp/amqp_management_link.rs
+++ b/src/amqp/amqp_management_link.rs
@@ -1,13 +1,76 @@
-use fe2o3_amqp::session::SessionHandle;
+use fe2o3_amqp::{session::SessionHandle, link::{SendError, LinkStateError}};
 use fe2o3_amqp_management::{MgmtClient, error::Error as ManagementError, Request, Response};
 use fe2o3_amqp_types::messaging::FromBody;
 
 use crate::util::sharable::Sharable;
 
+use super::{amqp_connection_scope::AmqpConnectionScope, error::OpenMgmtLinkError};
+
+#[derive(Debug)]
+enum State {
+    Recovering,
+    Connected {
+        session: SessionHandle<()>,
+        client: MgmtClient,
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct AmqpManagementLink {
-    pub(crate) _session_handle: SessionHandle<()>,
-    pub(crate) client: MgmtClient,
+    state: State,
+}
+
+impl AmqpManagementLink {
+    pub(crate) fn new(session: SessionHandle<()>, client: MgmtClient) -> Self {
+        let state = State::Connected {
+            session,
+            client,
+        };
+        Self {
+            state
+        }
+    }
+
+    pub(crate) async fn call<Req, Res>(&mut self, request: Req) -> Result<Res, ManagementError> 
+    where
+        Req: Request<Response = Res>,
+        Res: Response,
+        Res::Error: Into<ManagementError>,
+        for<'de> Res::Body: FromBody<'de> + std::fmt::Debug + Send,
+    {
+        match &mut self.state {
+            State::Recovering => {
+                Err(ManagementError::Send(SendError::LinkStateError(LinkStateError::IllegalSessionState)))
+            },
+            State::Connected { client, .. } => {
+                client.call(request).await
+            }
+        }
+    }
+
+    pub(crate) async fn recover(&mut self, scope: &mut AmqpConnectionScope) -> Result<(), OpenMgmtLinkError> {
+        log::debug!("Recovering management link");
+
+        // Close the old session and client
+        let old_state = std::mem::replace(&mut self.state, State::Recovering);
+        if let State::Connected { mut session, client } = old_state {
+            if let Err(err) = client.close().await {
+                log::error!("Found error closing management client during recovery: {:?}", err);
+            }
+            if let Err(err) = session.end().await {
+                log::error!("Found error closing management session during recovery: {:?}", err);
+            }
+        }
+
+        let (new_session, new_client) = scope.create_management_link().await?;
+        let new_state = State::Connected {
+            session: new_session,
+            client: new_client,
+        };
+        let _ = std::mem::replace(&mut self.state, new_state);
+
+        Ok(())
+    }
 }
 
 impl Sharable<AmqpManagementLink> {
@@ -19,10 +82,10 @@ impl Sharable<AmqpManagementLink> {
         for<'de> Res::Body: FromBody<'de> + std::fmt::Debug + Send,
     {
         match self {
-            Sharable::Owned(l) => l.client.call(request).await,
+            Sharable::Owned(l) => l.call(request).await,
             Sharable::Shared(lock) => {
                 let mut lock = lock.write().await;
-                lock.client.call(request).await
+                lock.call(request).await
             },
             Sharable::None => unreachable!(),
         }


### PR DESCRIPTION
This PR avoids the following issue #4 by:

1. Checks if the management client session is ended and only attempts recovery if the management client session is already ended.
2. Closes the existing management client and session before opening new management session and client.

> [2023-12-14 20:46:01] [azeventhubs::amqp::amqp_consumer::sin
gle] [ERROR] Failed to recover client: SenderResume(AttachError(RemoteClosedWithError(Error { condition: AmqpEr
ror(NotAllowed), description: Some("A link to connection '40123453' $management node has already been opened.")
, info: None })))