### PR TITLE
0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 0.18.2
+
+1. Added more debug logs
+2. Perform management client recovery anyway even if the management link session is still active
+   (currently there is no guarantee that the session will be closed when the link is closed, and
+    there is no cheap way to check if the management link is still active)
+
 ## 0.18.1
 
 1. Closes the old session and management link when recovering from a retryable error.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azeventhubs"
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 description = "An unofficial AMQP 1.0 rust client for Azure Event Hubs"
 readme = "README.md"

--- a/src/amqp/amqp_consumer/multiple.rs
+++ b/src/amqp/amqp_consumer/multiple.rs
@@ -297,6 +297,8 @@ where
             },
         };
 
+        log::debug!("Failed to receive event: {:?}", err);
+
         if err.is_scope_disposed() {
             return Some(Err(err));
         }

--- a/src/amqp/amqp_consumer/single.rs
+++ b/src/amqp/amqp_consumer/single.rs
@@ -202,6 +202,8 @@ where
                 Err(err) => err,
             };
 
+        log::debug!("Failed to receive batch: {:?}", err);
+
         if err.is_scope_disposed() {
             return Err(err);
         }
@@ -254,6 +256,8 @@ where
                 }
             }
         };
+
+        log::debug!("Failed to receive event: {:?}", err);
 
         if err.is_scope_disposed() {
             return Err(err);

--- a/src/amqp/amqp_management_link.rs
+++ b/src/amqp/amqp_management_link.rs
@@ -52,8 +52,7 @@ impl AmqpManagementLink {
         log::debug!("Recovering management link");
         if let State::Connected { session, .. } = &self.state {
             if !session.is_ended() {
-                log::debug!("Management session is not ended, skipping recovery");
-                return Ok(());
+                log::debug!("Management link session is still open, performing recovery anyway");
             }
         }
 

--- a/src/amqp/amqp_producer.rs
+++ b/src/amqp/amqp_producer.rs
@@ -175,6 +175,8 @@ where
                 Err(elapsed) => elapsed.into(),
             };
 
+            log::debug!("Failed to send batch: {:?}", err);
+
             // Scope is disposed, so we can't recover or retry
             if err.is_scope_disposed() {
                 return Err(err);

--- a/src/event_hubs_connection.rs
+++ b/src/event_hubs_connection.rs
@@ -245,6 +245,8 @@ impl EventHubConnection {
                 Err(elapsed) => elapsed.into(),
             };
 
+            log::debug!("get_properties failed: {:?}", error);
+
             failed_attempt += 1;
             let delay = retry_policy.calculate_retry_delay(&error, failed_attempt);
             should_try_recover = error.should_try_recover();
@@ -302,6 +304,8 @@ impl EventHubConnection {
                 Err(elapsed) => elapsed.into(),
             };
 
+            log::debug!("get_partition_properties failed: {:?}", error);
+
             failed_attempt += 1;
             let delay = retry_policy.calculate_retry_delay(&error, failed_attempt);
             should_try_recover = error.should_try_recover();
@@ -357,6 +361,7 @@ impl EventHubConnection {
                 Err(elapsed) => elapsed.into(),
             };
 
+            log::debug!("create producer failed: {:?}", error);
 
             failed_attempt += 1;
             let delay = retry_policy.calculate_retry_delay(&error, failed_attempt);
@@ -419,6 +424,8 @@ impl EventHubConnection {
                 Ok(Err(err)) => err,
                 Err(elapsed) => elapsed.into(),
             };
+
+            log::debug!("create consumer failed: {:?}", error);
 
             failed_attempt += 1;
             let delay = retry_policy.calculate_retry_delay(&error, failed_attempt);


### PR DESCRIPTION
1. Added more debug logs
2. Perform management client recovery anyway even if the management link session is still active
   (currently there is no guarantee that the session will be closed when the link is closed, and
    there is no cheap way to check if the management link is still active)