### PR TITLE
Use shorter type names 

### DIFF
--- a/benches/bench_event_stream.rs
+++ b/benches/bench_event_stream.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use azeventhubs::{
     consumer::{ConsumerClient, ConsumerClientOptions, ReadEventOptions},
-    Connection, RetryOptions, ReceivedEventData,
+    Connection, ReceivedEventData, RetryOptions,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures_util::{lock::Mutex, Stream};

--- a/benches/bench_event_stream.rs
+++ b/benches/bench_event_stream.rs
@@ -1,8 +1,8 @@
 use std::{sync::Arc, time::Duration};
 
 use azeventhubs::{
-    consumer::{EventHubConsumerClient, EventHubConsumerClientOptions, ReadEventOptions},
-    EventHubConnection, EventHubsRetryOptions, ReceivedEventData,
+    consumer::{ConsumerClient, ConsumerClientOptions, ReadEventOptions},
+    Connection, RetryOptions, ReceivedEventData,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures_util::{lock::Mutex, Stream};
@@ -38,12 +38,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     let n_prep = 10000;
     let partitions = rt.block_on(utils::prepare_events_on_all_partitions(n_prep));
 
-    let consumer_group = EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
-    let retry_options = EventHubsRetryOptions {
+    let consumer_group = ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
+    let retry_options = RetryOptions {
         try_timeout: Duration::from_secs(1), // fail early for benchmark
         ..Default::default()
     };
-    let client_options = EventHubConsumerClientOptions {
+    let client_options = ConsumerClientOptions {
         retry_options,
         ..Default::default()
     };
@@ -94,14 +94,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut consumer_clients = rt
         .block_on(async {
             let mut consumer_clients = Vec::new();
-            let mut connection = EventHubConnection::new_from_connection_string(
+            let mut connection = Connection::new_from_connection_string(
                 connection_string,
                 event_hub_name,
                 Default::default(),
             )
             .await?;
             for _ in partitions.iter() {
-                let consumer = EventHubConsumerClient::with_connection(
+                let consumer = ConsumerClient::with_connection(
                     consumer_group,
                     &mut connection,
                     client_options.clone(),

--- a/benches/bench_event_stream_start_up.rs
+++ b/benches/bench_event_stream_start_up.rs
@@ -2,8 +2,8 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 use azeventhubs::{
-    consumer::{EventHubConsumerClient, EventHubConsumerClientOptions, ReadEventOptions},
-    EventHubsRetryOptions,
+    consumer::{ConsumerClient, ConsumerClientOptions, ReadEventOptions},
+    RetryOptions,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use utils::{
@@ -53,12 +53,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     let n_prep = 1000;
     let partitions = rt.block_on(utils::prepare_events_on_all_partitions(n_prep));
 
-    let consumer_group = EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
-    let retry_options = EventHubsRetryOptions {
+    let consumer_group = ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
+    let retry_options = RetryOptions {
         try_timeout: Duration::from_secs(1), // fail early for benchmark
         ..Default::default()
     };
-    let client_options = EventHubConsumerClientOptions {
+    let client_options = ConsumerClientOptions {
         retry_options,
         ..Default::default()
     };

--- a/benches/utils.rs
+++ b/benches/utils.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 
 use azeventhubs::{
     consumer::{
-        self, ConsumerClient, ConsumerClientOptions, EventPosition, EventStream,
-        ReadEventOptions,
+        self, ConsumerClient, ConsumerClientOptions, EventPosition, EventStream, ReadEventOptions,
     },
     producer::{ProducerClient, SendEventOptions},
     BasicRetryPolicy, Connection, ReceivedEventData,

--- a/examples/consumer_read_from_position.rs
+++ b/examples/consumer_read_from_position.rs
@@ -2,7 +2,7 @@
 //! After that, it will start from the last known sequence number, and read another 30 events.
 
 use azeventhubs::consumer::{
-    EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions,
+    ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
 };
 use futures_util::StreamExt;
 
@@ -12,11 +12,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubConsumerClientOptions::default();
+    let options = ConsumerClientOptions::default();
 
     // Create a consumer client
-    let mut consumer_client = EventHubConsumerClient::new_from_connection_string(
-        EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    let mut consumer_client = ConsumerClient::new_from_connection_string(
+        ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
         connection_string,
         event_hub_name,
         options,

--- a/examples/consumer_with_azure_identity_credential.rs
+++ b/examples/consumer_with_azure_identity_credential.rs
@@ -1,5 +1,5 @@
 use azeventhubs::consumer::{
-    EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions,
+    ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
 };
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use futures_util::StreamExt;
@@ -13,21 +13,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = std::env::var("EVENT_HUBS_NAMESPACE")?;
     let fqn = format!("{}.servicebus.windows.net", namespace);
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubConsumerClientOptions::default();
+    let options = ConsumerClientOptions::default();
     let default_credential =
         DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
 
     // Create a consumer client
-    // let mut consumer_client = EventHubConsumerClient::new_from_connection_string(
-    //     EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    // let mut consumer_client = ConsumerClient::new_from_connection_string(
+    //     ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
     //     connection_string,
     //     event_hub_name,
     //     options,
     // )
     // .await?;
 
-    let mut consumer_client = EventHubConsumerClient::new_from_credential(
-        EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    let mut consumer_client = ConsumerClient::new_from_credential(
+        ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
         fqn,
         event_hub_name,
         default_credential,

--- a/examples/event_hub_connection_example.rs
+++ b/examples/event_hub_connection_example.rs
@@ -1,4 +1,4 @@
-use azeventhubs::{EventHubConnection, EventHubConnectionOptions};
+use azeventhubs::{Connection, ConnectionOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -6,9 +6,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH")?;
     let _event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubConnectionOptions::default();
+    let options = ConnectionOptions::default();
     let connection =
-        EventHubConnection::new_from_connection_string(connection_string, None, options).await?;
+        Connection::new_from_connection_string(connection_string, None, options).await?;
     connection.close().await?;
 
     Ok(())

--- a/examples/event_hub_consumer_example.rs
+++ b/examples/event_hub_consumer_example.rs
@@ -1,5 +1,5 @@
 use azeventhubs::consumer::{
-    EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions,
+    ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
 };
 use futures_util::StreamExt;
 
@@ -11,11 +11,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubConsumerClientOptions::default();
+    let options = ConsumerClientOptions::default();
 
     // Create a consumer client
-    let mut consumer_client = EventHubConsumerClient::new_from_connection_string(
-        EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    let mut consumer_client = ConsumerClient::new_from_connection_string(
+        ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
         connection_string,
         event_hub_name,
         options,

--- a/examples/event_hub_producer_example.rs
+++ b/examples/event_hub_producer_example.rs
@@ -1,6 +1,4 @@
-use azeventhubs::producer::{
-    ProducerClient, ProducerClientOptions, SendEventOptions,
-};
+use azeventhubs::producer::{ProducerClient, ProducerClientOptions, SendEventOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -11,12 +9,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
     let options = ProducerClientOptions::default();
-    let mut producer_client = ProducerClient::new_from_connection_string(
-        connection_string,
-        event_hub_name,
-        options,
-    )
-    .await?;
+    let mut producer_client =
+        ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            .await?;
 
     let partition_ids = producer_client.get_partition_ids().await?;
 

--- a/examples/event_hub_producer_example.rs
+++ b/examples/event_hub_producer_example.rs
@@ -1,5 +1,5 @@
 use azeventhubs::producer::{
-    EventHubProducerClient, EventHubProducerClientOptions, SendEventOptions,
+    ProducerClient, ProducerClientOptions, SendEventOptions,
 };
 
 #[tokio::main]
@@ -10,8 +10,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubProducerClientOptions::default();
-    let mut producer_client = EventHubProducerClient::new_from_connection_string(
+    let options = ProducerClientOptions::default();
+    let mut producer_client = ProducerClient::new_from_connection_string(
         connection_string,
         event_hub_name,
         options,

--- a/examples/event_hub_producer_send_batch.rs
+++ b/examples/event_hub_producer_send_batch.rs
@@ -1,6 +1,4 @@
-use azeventhubs::producer::{
-    ProducerClient, ProducerClientOptions, SendEventOptions, TryAddError,
-};
+use azeventhubs::producer::{ProducerClient, ProducerClientOptions, SendEventOptions, TryAddError};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -11,12 +9,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
     let options = ProducerClientOptions::default();
-    let mut producer_client = ProducerClient::new_from_connection_string(
-        connection_string,
-        event_hub_name,
-        options,
-    )
-    .await?;
+    let mut producer_client =
+        ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            .await?;
 
     let partition_ids = producer_client.get_partition_ids().await?;
 

--- a/examples/event_hub_producer_send_batch.rs
+++ b/examples/event_hub_producer_send_batch.rs
@@ -1,5 +1,5 @@
 use azeventhubs::producer::{
-    EventHubProducerClient, EventHubProducerClientOptions, SendEventOptions, TryAddError,
+    ProducerClient, ProducerClientOptions, SendEventOptions, TryAddError,
 };
 
 #[tokio::main]
@@ -10,8 +10,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubProducerClientOptions::default();
-    let mut producer_client = EventHubProducerClient::new_from_connection_string(
+    let options = ProducerClientOptions::default();
+    let mut producer_client = ProducerClient::new_from_connection_string(
         connection_string,
         event_hub_name,
         options,

--- a/examples/event_hub_spawn_consumer_example.rs
+++ b/examples/event_hub_spawn_consumer_example.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use azeventhubs::consumer::{
-    EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions,
+    ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
 };
 use futures_util::lock::Mutex;
 use futures_util::StreamExt;
@@ -14,11 +14,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubConsumerClientOptions::default();
+    let options = ConsumerClientOptions::default();
 
     // Create a consumer client
-    let mut consumer_client = EventHubConsumerClient::new_from_connection_string(
-        EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    let mut consumer_client = ConsumerClient::new_from_connection_string(
+        ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
         connection_string,
         event_hub_name,
         options,

--- a/examples/producer_with_azure_identity_credential.rs
+++ b/examples/producer_with_azure_identity_credential.rs
@@ -1,6 +1,4 @@
-use azeventhubs::producer::{
-    ProducerClient, ProducerClientOptions, SendEventOptions,
-};
+use azeventhubs::producer::{ProducerClient, ProducerClientOptions, SendEventOptions};
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 
 #[tokio::main]
@@ -15,13 +13,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let default_credential =
         DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
 
-    let mut producer_client = ProducerClient::new_from_credential(
-        fqn,
-        event_hub_name,
-        default_credential,
-        options,
-    )
-    .await?;
+    let mut producer_client =
+        ProducerClient::new_from_credential(fqn, event_hub_name, default_credential, options)
+            .await?;
 
     log::info!("Sending a test event");
 

--- a/examples/producer_with_azure_identity_credential.rs
+++ b/examples/producer_with_azure_identity_credential.rs
@@ -1,5 +1,5 @@
 use azeventhubs::producer::{
-    EventHubProducerClient, EventHubProducerClientOptions, SendEventOptions,
+    ProducerClient, ProducerClientOptions, SendEventOptions,
 };
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 
@@ -11,11 +11,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = std::env::var("EVENT_HUBS_NAMESPACE")?;
     let fqn = format!("{}.servicebus.windows.net", namespace);
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let options = EventHubProducerClientOptions::default();
+    let options = ProducerClientOptions::default();
     let default_credential =
         DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
 
-    let mut producer_client = EventHubProducerClient::new_from_credential(
+    let mut producer_client = ProducerClient::new_from_credential(
         fqn,
         event_hub_name,
         default_credential,

--- a/examples/read_iothub_builtin_endpoints.rs
+++ b/examples/read_iothub_builtin_endpoints.rs
@@ -1,6 +1,4 @@
-use azeventhubs::consumer::{
-    ConsumerClient, ConsumerClientOptions, ReadEventOptions,
-};
+use azeventhubs::consumer::{ConsumerClient, ConsumerClientOptions, ReadEventOptions};
 use futures_util::StreamExt;
 
 #[tokio::main]

--- a/examples/read_iothub_builtin_endpoints.rs
+++ b/examples/read_iothub_builtin_endpoints.rs
@@ -1,5 +1,5 @@
 use azeventhubs::consumer::{
-    EventHubConsumerClient, EventHubConsumerClientOptions, ReadEventOptions,
+    ConsumerClient, ConsumerClientOptions, ReadEventOptions,
 };
 use futures_util::StreamExt;
 
@@ -10,11 +10,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = dotenv::from_filename(".env");
 
     let connection_string = std::env::var("IOTHUB_BUILTIN_CONNECTION_STRING")?;
-    let options = EventHubConsumerClientOptions::default();
+    let options = ConsumerClientOptions::default();
 
     // Create a consumer client
-    let mut consumer_client = EventHubConsumerClient::new_from_connection_string(
-        // EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    let mut consumer_client = ConsumerClient::new_from_connection_string(
+        // ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
         "$default",
         connection_string.clone(),
         None,

--- a/examples/spawn_multiple_consumer.rs
+++ b/examples/spawn_multiple_consumer.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use azeventhubs::consumer::{
-    EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions,
+    ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
 };
 use futures_util::StreamExt;
 use tokio_util::sync::CancellationToken;
@@ -16,11 +16,11 @@ async fn consumer_main(
     index: usize,
     connection_string: impl Into<String>,
     event_hub_name: impl Into<String>,
-    client_options: EventHubConsumerClientOptions,
+    client_options: ConsumerClientOptions,
     cancel: CancellationToken,
 ) -> Result<(), azure_core::Error> {
-    let mut consumer = EventHubConsumerClient::new_from_connection_string(
-        EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+    let mut consumer = ConsumerClient::new_from_connection_string(
+        ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
         connection_string,
         event_hub_name.into(),
         client_options,
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING")?;
     let event_hub_name = std::env::var("EVENT_HUB_NAME")?;
-    let client_options = EventHubConsumerClientOptions::default();
+    let client_options = ConsumerClientOptions::default();
 
     // We are going to use a cancellation token to stop the spawned tasks.
     let cancel = CancellationToken::new();

--- a/src/amqp/amqp_client.rs
+++ b/src/amqp/amqp_client.rs
@@ -7,8 +7,8 @@ use crate::{
     authorization::{event_hub_claim, event_hub_token_credential::EventHubTokenCredential},
     consumer::EventPosition,
     core::{RecoverableTransport, TransportClient, TransportProducerFeatures},
-    event_hubs_connection_option::EventHubConnectionOptions,
-    event_hubs_properties::EventHubProperties,
+    event_hubs_connection_option::ConnectionOptions,
+    event_hubs_properties::Properties,
     event_hubs_retry_policy::EventHubsRetryPolicy,
     producer::PartitionPublishingOptions,
     util::sharable::Sharable,
@@ -55,7 +55,7 @@ impl AmqpClient {
         host: &str,
         event_hub_name: Arc<String>,
         credential: EventHubTokenCredential,
-        options: EventHubConnectionOptions,
+        options: ConnectionOptions,
     ) -> Result<Self, AmqpClientError> {
         // Scheme of service endpoint must always be either "amqp" or "amqps"
         let service_endpoint = format!("{}://{}", options.transport_type.url_scheme(), host);
@@ -109,7 +109,7 @@ impl TransportClient for AmqpClient {
 
     async fn get_properties(
         &mut self,
-    ) -> Result<EventHubProperties, Self::RequestResponseError> {
+    ) -> Result<Properties, Self::RequestResponseError> {
         let access_token = self
             .connection_scope
             .credential

--- a/src/amqp/amqp_consumer/mod.rs
+++ b/src/amqp/amqp_consumer/mod.rs
@@ -198,13 +198,13 @@ where
 pin_project_lite::pin_project! {
     /// A stream of event.
     ///
-    /// This is created by a `EventHubConsumerClient`. It takes the lifetime of the
-    /// `EventHubConsumerClient` that created it, and thus the stream must be closed/dropped before
-    /// the `EventHubConsumerClient` is dropped.
+    /// This is created by a `ConsumerClient`. It takes the lifetime of the
+    /// `ConsumerClient` that created it, and thus the stream must be closed/dropped before
+    /// the `ConsumerClient` is dropped.
     ///
     /// # Generic Parameters:
     ///
-    /// * `'a` - The lifetime of the `EventHubConsumerClient` that created this stream.
+    /// * `'a` - The lifetime of the `ConsumerClient` that created this stream.
     /// * `RP` - The retry policy to use for recovering from errors.
     pub struct EventStream<'a, RP> {
         #[pin]

--- a/src/amqp/amqp_management/event_hub_properties.rs
+++ b/src/amqp/amqp_management/event_hub_properties.rs
@@ -8,7 +8,7 @@ use fe2o3_amqp_types::{
 use serde_amqp::Value;
 use time::OffsetDateTime;
 
-use crate::{amqp::amqp_management::response_map, event_hubs_properties::EventHubProperties};
+use crate::{amqp::amqp_management::response_map, event_hubs_properties::Properties};
 
 use super::{
     EVENT_HUB_RESOURCE_TYPE_VALUE, READ_OPERATION_VALUE, RESOURCE_NAME_KEY, RESOURCE_TYPE_KEY,
@@ -49,7 +49,7 @@ fn encode_application_properties(
 impl<'a> Request for EventHubPropertiesRequest<'a> {
     const OPERATION: &'static str = READ_OPERATION_VALUE;
 
-    type Response = EventHubProperties;
+    type Response = Properties;
 
     type Body = ();
 
@@ -66,7 +66,7 @@ impl<'a> Request for EventHubPropertiesRequest<'a> {
 impl<'a> Request for &'a EventHubPropertiesRequest<'a> {
     const OPERATION: &'static str = READ_OPERATION_VALUE;
 
-    type Response = EventHubProperties;
+    type Response = Properties;
 
     type Body = ();
 
@@ -83,7 +83,7 @@ impl<'a> Request for &'a EventHubPropertiesRequest<'a> {
 impl<'a> Request for &'a mut EventHubPropertiesRequest<'a> {
     const OPERATION: &'static str = READ_OPERATION_VALUE;
 
-    type Response = EventHubProperties;
+    type Response = Properties;
 
     type Body = ();
 
@@ -99,7 +99,7 @@ impl<'a> Request for &'a mut EventHubPropertiesRequest<'a> {
 
 type EventHubPropertiesResponseBody = OrderedMap<String, Value>;
 
-impl Response for EventHubProperties {
+impl Response for Properties {
     type Body = EventHubPropertiesResponseBody;
 
     const STATUS_CODE: u16 = 200;
@@ -131,7 +131,7 @@ impl Response for EventHubProperties {
             _ => return Err(ManagementError::DecodeError(None)),
         };
 
-        Ok(EventHubProperties {
+        Ok(Properties {
             name,
             created_on,
             partition_ids,

--- a/src/authorization/signautre_authorization_resource.rs
+++ b/src/authorization/signautre_authorization_resource.rs
@@ -1,6 +1,6 @@
 use url::Url;
 
-use crate::EventHubsTransportType;
+use crate::TransportType;
 
 /// Errors that can occur when building the signature authorization resource for connection.
 #[derive(Debug, thiserror::Error)]
@@ -25,7 +25,7 @@ pub enum BuildResourceError {
 /// Builds the fully-qualified identifier for the connection, for use with signature-based
 /// authorization.
 pub fn build_connection_signature_authorization_resource(
-    transport_type: EventHubsTransportType,
+    transport_type: TransportType,
     fully_qualified_namespace: Option<&str>,
     event_hub_name: Option<&str>,
 ) -> Result<String, BuildResourceError> {

--- a/src/consumer/event_hub_consumer_client_options.rs
+++ b/src/consumer/event_hub_consumer_client_options.rs
@@ -1,14 +1,14 @@
-use crate::{EventHubConnectionOptions, EventHubsRetryOptions};
+use crate::{ConnectionOptions, RetryOptions};
 
 /// The set of options that can be specified when creating an
-/// [`crate::consumer::EventHubConsumerClient`] to configure its behavior.
+/// [`crate::consumer::ConsumerClient`] to configure its behavior.
 #[derive(Debug, PartialEq, Eq, Clone, Default, Hash)]
-pub struct EventHubConsumerClientOptions {
+pub struct ConsumerClientOptions {
     /// The set of options that can be specified when creating an Event Hub connection.
-    pub connection_options: EventHubConnectionOptions,
+    pub connection_options: ConnectionOptions,
 
     /// The set of options that can be specified when retrying operations.
-    pub retry_options: EventHubsRetryOptions,
+    pub retry_options: RetryOptions,
 
     /// The identifier of the consumer. If not specified, a UUID will be generated.
     pub identifier: Option<String>,

--- a/src/consumer/event_position.rs
+++ b/src/consumer/event_position.rs
@@ -4,7 +4,7 @@ const START_OF_STREAM_OFFSET: &str = "-1";
 const END_OF_STREAM_OFFSET: &str = "@latest";
 
 /// The position of events in an Event Hub partition, typically used in the creation of
-/// an [`crate::consumer::EventHubConsumerClient`].
+/// an [`crate::consumer::ConsumerClient`].
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum EventPosition {
     /// The offset of the event identified by this position.

--- a/src/consumer/read_event_options.rs
+++ b/src/consumer/read_event_options.rs
@@ -2,7 +2,7 @@
 pub const DEFAULT_PREFETCH_COUNT: u32 = 300;
 
 /// The set of options that can be specified to configure behavior when reading events from an
-/// `EventHubConsumerClient`
+/// `ConsumerClient`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ReadEventOptions {
     /// The number of events that will be eagerly requested from the Event Hubs service and queued

--- a/src/core/basic_retry_policy.rs
+++ b/src/core/basic_retry_policy.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use rand::Rng;
 
 use crate::{
-    event_hubs_retry_mode::EventHubsRetryMode, event_hubs_retry_options::EventHubsRetryOptions,
+    event_hubs_retry_mode::RetryMode, event_hubs_retry_options::RetryOptions,
     event_hubs_retry_policy::EventHubsRetryPolicy,
 };
 
@@ -14,7 +14,7 @@ const DEFAULT_JITTER_FACTOR: f64 = 0.08;
 /// Default retry policy used by the client.
 #[derive(Debug, Clone)]
 pub struct BasicRetryPolicy {
-    options: EventHubsRetryOptions,
+    options: RetryOptions,
     jitter_factor: f64,
     // /// The minimum number of seconds to wait before retrying when the service
     // /// indicates that the client should throttle its requests.
@@ -31,7 +31,7 @@ pub struct BasicRetryPolicy {
 
 impl BasicRetryPolicy {
     /// The set of options used to configure the retry policy.
-    pub fn options(&self) -> &EventHubsRetryOptions {
+    pub fn options(&self) -> &RetryOptions {
         &self.options
     }
 
@@ -41,8 +41,8 @@ impl BasicRetryPolicy {
     }
 }
 
-impl From<EventHubsRetryOptions> for BasicRetryPolicy {
-    fn from(options: EventHubsRetryOptions) -> Self {
+impl From<RetryOptions> for BasicRetryPolicy {
+    fn from(options: RetryOptions) -> Self {
         Self {
             options,
             jitter_factor: DEFAULT_JITTER_FACTOR,
@@ -72,10 +72,10 @@ impl EventHubsRetryPolicy for BasicRetryPolicy {
 
         let base_jitter_seconds = self.options.delay.as_secs_f64() * self.jitter_factor;
         let retry_delay = match &self.options.mode {
-            EventHubsRetryMode::Fixed => {
+            RetryMode::Fixed => {
                 calculate_fixed_delay(self.options.delay.as_secs_f64(), base_jitter_seconds)
             }
-            EventHubsRetryMode::Exponential => calculate_exponential_delay(
+            RetryMode::Exponential => calculate_exponential_delay(
                 self.options.delay.as_secs_f64(),
                 base_jitter_seconds,
                 attempt_count,

--- a/src/core/transport_client.rs
+++ b/src/core/transport_client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    consumer::EventPosition, event_hubs_properties::EventHubProperties,
+    consumer::EventPosition, event_hubs_properties::Properties,
     event_hubs_retry_policy::EventHubsRetryPolicy, producer::PartitionPublishingOptions,
     PartitionProperties,
 };
@@ -25,7 +25,7 @@ pub trait TransportClient: Sized {
 
     async fn get_properties(
         &mut self,
-    ) -> Result<EventHubProperties, Self::RequestResponseError>;
+    ) -> Result<Properties, Self::RequestResponseError>;
 
     async fn get_partition_properties(
         &mut self,

--- a/src/event_hubs_connection_option.rs
+++ b/src/event_hubs_connection_option.rs
@@ -1,17 +1,17 @@
 use std::time::Duration;
 use url::Url;
 
-use crate::event_hubs_transport_type::EventHubsTransportType;
+use crate::event_hubs_transport_type::TransportType;
 
-/// The set of options that can be specified when creating [`crate::EventHubConnection`]
+/// The set of options that can be specified when creating [`crate::Connection`]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct EventHubConnectionOptions {
+pub struct ConnectionOptions {
     /// The amount of time to allow a connection to have no observed traffic before considering it idle
     pub connection_idle_timeout: Duration,
 
     /// The type of protocol and transport that will be used for communicating with the Event Hubs
     /// service.
-    pub transport_type: EventHubsTransportType,
+    pub transport_type: TransportType,
 
     // send_buffer_size_in_bytes: usize, // TODO: need upstream to support changing buffer size
     // receive_buffer_size_in_bytes: usize, // TODO: need upstream to support changing buffer size
@@ -19,7 +19,7 @@ pub struct EventHubConnectionOptions {
     pub custom_endpoint_address: Option<Url>,
 }
 
-impl Default for EventHubConnectionOptions {
+impl Default for ConnectionOptions {
     fn default() -> Self {
         Self {
             connection_idle_timeout: Duration::from_secs(60),
@@ -29,8 +29,8 @@ impl Default for EventHubConnectionOptions {
     }
 }
 
-impl EventHubConnectionOptions {
-    /// Create a new instance of [`EventHubConnectionOptions`] with default values
+impl ConnectionOptions {
+    /// Create a new instance of [`ConnectionOptions`] with default values
     pub fn new() -> Self {
         Default::default()
     }

--- a/src/event_hubs_connection_string_properties.rs
+++ b/src/event_hubs_connection_string_properties.rs
@@ -48,7 +48,7 @@ impl From<ToConnectionStringError> for azure_core::Error {
 
 /// The set of properties that comprise a Event Hubs connection string.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct EventHubsConnectionStringProperties<'a> {
+pub struct ConnectionStringProperties<'a> {
     pub(crate) endpoint: Option<url::Url>,
     pub(crate) event_hub_name: Option<&'a str>,
     pub(crate) shared_access_key_name: Option<&'a str>,
@@ -56,7 +56,7 @@ pub struct EventHubsConnectionStringProperties<'a> {
     pub(crate) shared_access_signature: Option<&'a str>,
 }
 
-impl<'a> EventHubsConnectionStringProperties<'a> {
+impl<'a> ConnectionStringProperties<'a> {
     /// The character used to separate a token and its value in the connection string.
     const TOKEN_VALUE_SEPARATOR: char = '=';
 
@@ -117,7 +117,7 @@ impl<'a> EventHubsConnectionStringProperties<'a> {
     }
 
     /// Creates an Event Hubs connection string based on this set of
-    /// [`EventHubsConnectionStringProperties`].
+    /// [`ConnectionStringProperties`].
     pub fn to_connection_string(&self) -> Result<String, ToConnectionStringError> {
         let mut s = String::new();
 
@@ -250,7 +250,7 @@ impl<'a> EventHubsConnectionStringProperties<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{EventHubsConnectionStringProperties, FormatError};
+    use super::{ConnectionStringProperties, FormatError};
 
     const ENDPOINT: &str = "test.endpoint.com";
     const EVENT_HUB: &str = "some-path";
@@ -268,7 +268,7 @@ mod tests {
 
     macro_rules! assert_parsed_and_expected {
         ($connection_string:ident, $expected:ident) => {
-            let parsed = EventHubsConnectionStringProperties::parse(&$connection_string).unwrap();
+            let parsed = ConnectionStringProperties::parse(&$connection_string).unwrap();
 
             assert_eq!(
                 parsed.endpoint().and_then(|url| url.host_str()),
@@ -478,10 +478,10 @@ mod tests {
     }
 
     fn to_connection_string_validates_properties_cases(
-    ) -> Vec<EventHubsConnectionStringProperties<'static>> {
+    ) -> Vec<ConnectionStringProperties<'static>> {
         let mut cases = Vec::new();
         // "missing endpoint"
-        let case = EventHubsConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: None,
             event_hub_name: Some("fake"),
             shared_access_signature: Some("fake"),
@@ -491,7 +491,7 @@ mod tests {
         cases.push(case);
 
         // "missing authorization"
-        let case = EventHubsConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             event_hub_name: Some("fake"),
             shared_access_signature: None,
@@ -501,7 +501,7 @@ mod tests {
         cases.push(case);
 
         // "SAS and key specified"
-        let case = EventHubsConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             event_hub_name: Some("fake"),
             shared_access_signature: Some("fake"),
@@ -511,7 +511,7 @@ mod tests {
         cases.push(case);
 
         // "SAS and shared key name specified"
-        let case = EventHubsConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             event_hub_name: Some("fake"),
             shared_access_signature: Some("fake"),
@@ -521,7 +521,7 @@ mod tests {
         cases.push(case);
 
         // "only shared key name specified"
-        let case = EventHubsConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             event_hub_name: Some("fake"),
             shared_access_signature: None,
@@ -531,7 +531,7 @@ mod tests {
         cases.push(case);
 
         // "only shared key specified"
-        let case = EventHubsConnectionStringProperties {
+        let case = ConnectionStringProperties {
             endpoint: Some(url::Url::parse("sb://someplace.hosname.ext").unwrap()),
             event_hub_name: Some("fake"),
             shared_access_signature: None,
@@ -550,7 +550,7 @@ mod tests {
         let sas_key_name = "sasName";
         let shared_access_signature = "fakeSAS";
         let connection_string = format!("Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};SharedAccessKey={sas_key};SharedAccessSignature={shared_access_signature}");
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -573,7 +573,7 @@ mod tests {
         let sas_key_name = "sasName";
         let shared_access_signature = "fakeSAS";
         let connection_string = format!("Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};SharedAccessKey={sas_key};EntityPath={event_hub};SharedAccessSignature={shared_access_signature}");
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -604,7 +604,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!(";Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};SharedAccessKey={sas_key};EntityPath={event_hub}");
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -622,7 +622,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!("Endpoint=sb://{endpoint}; SharedAccessKeyName={sas_key_name}; SharedAccessKey={sas_key}; EntityPath={event_hub}");
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -640,7 +640,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!("Endpoint = sb://{endpoint};SharedAccessKeyName ={sas_key_name};SharedAccessKey= {sas_key}; EntityPath  =  {event_hub}");
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -667,7 +667,7 @@ mod tests {
         let sas_key = "sasKey";
         let sas_key_name = "sasName";
         let connection_string = format!("Endpoint=sb://{endpoint};SharedAccessKeyName={sas_key_name};Unknown=INVALID;SharedAccessKey={sas_key};EntityPath={event_hub};Trailing=WHOAREYOU");
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+        let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
         assert_eq!(
             parsed.endpoint().and_then(|url| url.host_str()),
@@ -691,7 +691,7 @@ mod tests {
 
         for endpoint_value in endpoint_values {
             let connection_string = format!("Endpoint={};EntityPath=dummy", endpoint_value);
-            let parsed = EventHubsConnectionStringProperties::parse(&connection_string).unwrap();
+            let parsed = ConnectionStringProperties::parse(&connection_string).unwrap();
 
             assert_eq!(
                 parsed.endpoint().and_then(|url| url.host_str()),
@@ -704,7 +704,7 @@ mod tests {
     fn parse_does_not_allow_an_invalid_endpoint_format() {
         let endpoint = "test.endpoint.com";
         let connection_string = format!("Endpoint={}", endpoint);
-        let result = EventHubsConnectionStringProperties::parse(&connection_string);
+        let result = ConnectionStringProperties::parse(&connection_string);
         assert!(result.is_err());
     }
 
@@ -720,7 +720,7 @@ mod tests {
         ];
 
         for test_case in test_cases {
-            let result = EventHubsConnectionStringProperties::parse(test_case);
+            let result = ConnectionStringProperties::parse(test_case);
             assert_eq!(result, Err(FormatError::InvalidConnectionString));
         }
     }
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn to_connection_string_produces_the_connection_string_for_shared_access_signatures() {
-        let properties = EventHubsConnectionStringProperties {
+        let properties = ConnectionStringProperties {
             endpoint: Some("sb://place.endpoint.ext".parse().unwrap()),
             event_hub_name: Some("HubName"),
             shared_access_signature: Some("FaKe#$1324@@"),
@@ -750,14 +750,14 @@ mod tests {
         let connection_string = connection_string.unwrap();
         assert!(!connection_string.is_empty());
 
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string);
+        let parsed = ConnectionStringProperties::parse(&connection_string);
         assert!(parsed.is_ok());
         assert_eq!(properties, parsed.unwrap());
     }
 
     #[test]
     fn to_connection_string_produces_the_connection_string_for_shared_keys() {
-        let properties = EventHubsConnectionStringProperties {
+        let properties = ConnectionStringProperties {
             endpoint: Some("sb://place.endpoint.ext".parse().unwrap()),
             event_hub_name: Some("HubName"),
             shared_access_signature: None,
@@ -770,7 +770,7 @@ mod tests {
         let connection_string = connection_string.unwrap();
         assert!(!connection_string.is_empty());
 
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string);
+        let parsed = ConnectionStringProperties::parse(&connection_string);
         assert!(parsed.is_ok());
         assert_eq!(properties, parsed.unwrap());
     }
@@ -785,7 +785,7 @@ mod tests {
 
         for scheme in schemes {
             let endpoint = format!("{}myhub.servicebus.windows.net", scheme);
-            let properties = EventHubsConnectionStringProperties {
+            let properties = ConnectionStringProperties {
                 endpoint: Some(url::Url::parse(&endpoint).unwrap()),
                 event_hub_name: Some("HubName"),
                 shared_access_signature: None,
@@ -801,7 +801,7 @@ mod tests {
     #[test]
     fn to_connection_string_returns_ok_with_servicebus_endpoint_scheme() {
         let endpoint = "sb://myhub.servicebus.windows.net";
-        let properties = EventHubsConnectionStringProperties {
+        let properties = ConnectionStringProperties {
             endpoint: Some(url::Url::parse(endpoint).unwrap()),
             event_hub_name: Some("HubName"),
             shared_access_signature: None,
@@ -813,7 +813,7 @@ mod tests {
         assert!(connection_string.is_ok());
         let connection_string = connection_string.unwrap();
 
-        let parsed = EventHubsConnectionStringProperties::parse(&connection_string);
+        let parsed = ConnectionStringProperties::parse(&connection_string);
         assert!(parsed.is_ok());
         assert_eq!(properties, parsed.unwrap());
     }
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn to_connection_string_allows_shared_access_key_authorization() {
         let fake_connection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]";
-        let properties = EventHubsConnectionStringProperties::parse(fake_connection).unwrap();
+        let properties = ConnectionStringProperties::parse(fake_connection).unwrap();
 
         assert!(properties.to_connection_string().is_ok());
     }
@@ -830,7 +830,7 @@ mod tests {
     fn to_connection_string_allows_shared_access_signature_authorization() {
         let fake_connection =
             "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessSignature=[not_real]";
-        let properties = EventHubsConnectionStringProperties::parse(fake_connection).unwrap();
+        let properties = ConnectionStringProperties::parse(fake_connection).unwrap();
 
         assert!(properties.to_connection_string().is_ok());
     }

--- a/src/event_hubs_properties.rs
+++ b/src/event_hubs_properties.rs
@@ -2,13 +2,13 @@ use time::OffsetDateTime;
 
 /// A set of information for an Event Hub.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct EventHubProperties {
+pub struct Properties {
     pub(crate) name: String,
     pub(crate) created_on: OffsetDateTime,
     pub(crate) partition_ids: Vec<String>,
 }
 
-impl EventHubProperties {
+impl Properties {
     /// The name of the Event Hub, specific to the namespace that contains it.
     pub fn name(&self) -> &str {
         &self.name

--- a/src/event_hubs_retry_mode.rs
+++ b/src/event_hubs_retry_mode.rs
@@ -1,7 +1,7 @@
 /// The type of approach to apply when calculating the delay
 /// between retry attempts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EventHubsRetryMode {
+pub enum RetryMode {
     /// Retry attempts happen at fixed intervals; each delay is a consistent duration
     Fixed,
 
@@ -9,7 +9,7 @@ pub enum EventHubsRetryMode {
     Exponential,
 }
 
-impl Default for EventHubsRetryMode {
+impl Default for RetryMode {
     fn default() -> Self {
         Self::Exponential
     }

--- a/src/event_hubs_retry_options.rs
+++ b/src/event_hubs_retry_options.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::event_hubs_retry_mode::EventHubsRetryMode;
+use crate::event_hubs_retry_mode::RetryMode;
 
 const MAX_RETRIES: u32 = 100;
 const DEFAULT_MAX_RETRIES: u32 = 3;
@@ -46,7 +46,7 @@ impl TryFrom<u32> for MaxRetries {
 /// The set of options that can be specified to influence how
 /// retry attempts are made, and a failure is eligible to be retried.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct EventHubsRetryOptions {
+pub struct RetryOptions {
     /// The maximum number of retry attempts before considering the associated operation to have failed
     pub max_retries: MaxRetries,
 
@@ -61,29 +61,29 @@ pub struct EventHubsRetryOptions {
 
     /// The approach to use for calculating retry delays
     ///
-    /// The default retry mode is [`EventHubsRetryMode::Exponential`]
-    pub mode: EventHubsRetryMode,
+    /// The default retry mode is [`RetryMode::Exponential`]
+    pub mode: RetryMode,
 }
 
-impl Default for EventHubsRetryOptions {
+impl Default for RetryOptions {
     fn default() -> Self {
         Self {
             max_retries: MaxRetries::default(),
             delay: DEFAULT_DELAY,
             maximum_delay: DEFAULT_MAXIMUM_DELAY,
             try_timeout: DEFAULT_TRY_TIMEOUT,
-            mode: EventHubsRetryMode::default(),
+            mode: RetryMode::default(),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{EventHubsRetryOptions, MaxRetries, event_hubs_retry_options::{DEFAULT_MAXIMUM_DELAY, DEFAULT_DELAY, DEFAULT_TRY_TIMEOUT}, EventHubsRetryMode};
+    use crate::{RetryOptions, MaxRetries, event_hubs_retry_options::{DEFAULT_MAXIMUM_DELAY, DEFAULT_DELAY, DEFAULT_TRY_TIMEOUT}, RetryMode};
 
     #[test]
     fn default_values() {
-        let options = EventHubsRetryOptions {
+        let options = RetryOptions {
             max_retries: MaxRetries::try_from(5).unwrap(),
             ..Default::default()
         };
@@ -92,6 +92,6 @@ mod tests {
         assert_eq!(options.delay, DEFAULT_DELAY);
         assert_eq!(options.maximum_delay, DEFAULT_MAXIMUM_DELAY);
         assert_eq!(options.try_timeout, DEFAULT_TRY_TIMEOUT);
-        assert_eq!(options.mode, EventHubsRetryMode::default());
+        assert_eq!(options.mode, RetryMode::default());
     }
 }

--- a/src/event_hubs_transport_type.rs
+++ b/src/event_hubs_transport_type.rs
@@ -3,7 +3,7 @@
 ///
 /// This is a simple enum, so copying it is cheap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum EventHubsTransportType {
+pub enum TransportType {
     /// The connection uses the AMQP protocol over TCP
     AmqpTcp,
 
@@ -11,13 +11,13 @@ pub enum EventHubsTransportType {
     AmqpWebSockets,
 }
 
-impl Default for EventHubsTransportType {
+impl Default for TransportType {
     fn default() -> Self {
         Self::AmqpTcp
     }
 }
 
-impl EventHubsTransportType {
+impl TransportType {
     pub(crate) const AMQP_SCHEME: &'static str = "amqps";
     pub(crate) const WEBSOCKET_SCHEME: &'static str = "wss";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,16 +11,16 @@
 //!
 //! ```no_run
 //! use azeventhubs::producer::{
-//! EventHubProducerClient, EventHubProducerClientOptions, SendEventOptions,
+//! ProducerClient, ProducerClientOptions, SendEventOptions,
 //! };
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let mut producer_client =
-//!         EventHubProducerClient::new_from_connection_string(
+//!         ProducerClient::new_from_connection_string(
 //!             "<CONNECTION_STRING>", // Replace with your connection string
 //!             "<EVENT_HUB_NAME>".to_string(), // Replace with your hub name
-//!             EventHubProducerClientOptions::default()
+//!             ProducerClientOptions::default()
 //!        ).await?;
 //!
 //!     let partition_ids = producer_client.get_partition_ids().await?;
@@ -39,17 +39,17 @@
 //!
 //! ```no_run
 //! use futures_util::StreamExt;
-//! use azeventhubs::consumer::{EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions};
+//! use azeventhubs::consumer::{ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create a consumer client
 //!     let mut consumer_client =
-//!         EventHubConsumerClient::new_from_connection_string(
-//!             EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
+//!         ConsumerClient::new_from_connection_string(
+//!             ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME,
 //!             "<CONNECTION_STRING>", // Replace with your connection string
 //!             "<EVENT_HUB_NAME>".to_string(), // Replace with your hub name
-//!             EventHubConsumerClientOptions::default(),
+//!             ConsumerClientOptions::default(),
 //!         ).await?;
 //!
 //!     let partition_ids = consumer_client.get_partition_ids().await?;

--- a/src/primitives/partition_receiver_options.rs
+++ b/src/primitives/partition_receiver_options.rs
@@ -1,6 +1,6 @@
 use std::time::Duration as StdDuration;
 
-use crate::{EventHubConnectionOptions, EventHubsRetryOptions};
+use crate::{ConnectionOptions, RetryOptions};
 
 /// The default amount of time to wait for messages when reading
 pub const DEFAULT_MAXIMUM_RECEIVE_WAIT_TIME: StdDuration = StdDuration::from_secs(60);
@@ -12,11 +12,11 @@ pub const DEFAULT_PREFETCH_COUNT: u32 = 300;
 /// [`crate::primitives::PartitionReceiver`]
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct PartitionReceiverOptions {
-    /// The set of options that can be specified when creating an [`crate::EventHubConnection`]
-    pub connection_options: EventHubConnectionOptions,
+    /// The set of options that can be specified when creating an [`crate::Connection`]
+    pub connection_options: ConnectionOptions,
 
     /// The set of options to govern retry behavior and try timeouts.
-    pub retry_options: EventHubsRetryOptions,
+    pub retry_options: RetryOptions,
 
     /// The amount of time to wait for messages when reading
     pub maximum_receive_wait_time: StdDuration,

--- a/src/producer/event_hub_producer_client_options.rs
+++ b/src/producer/event_hub_producer_client_options.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 
 use crate::{
-    core::TransportProducerFeatures, event_hubs_retry_options::EventHubsRetryOptions,
-    EventHubConnectionOptions,
+    core::TransportProducerFeatures, event_hubs_retry_options::RetryOptions,
+    ConnectionOptions,
 };
 
 use super::PartitionPublishingOptions;
 
 /// The set of options that can be specified when creating an Event Hub producer.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-pub struct EventHubProducerClientOptions {
+pub struct ProducerClientOptions {
     /// The set of options that can be specified when creating an Event Hub connection.
-    pub connection_options: EventHubConnectionOptions,
+    pub connection_options: ConnectionOptions,
 
     /// The set of options that can be specified when retrying operations.
-    pub retry_options: EventHubsRetryOptions,
+    pub retry_options: RetryOptions,
 
     /// The identifier of the producer. If not specified, a UUID will be generated.
     pub identifier: Option<String>,
@@ -23,7 +23,7 @@ pub struct EventHubProducerClientOptions {
     pub partition_options: HashMap<String, PartitionPublishingOptions>,
 }
 
-impl EventHubProducerClientOptions {
+impl ProducerClientOptions {
     pub(crate) fn create_features(&self) -> TransportProducerFeatures {
         TransportProducerFeatures::None
     }

--- a/src/producer/partition_publishing_options.rs
+++ b/src/producer/partition_publishing_options.rs
@@ -1,4 +1,4 @@
-/// The set of options that can be specified for an <see cref="EventHubProducerClient" />
+/// The set of options that can be specified for an <see cref="ProducerClient" />
 /// to influence its behavior when publishing directly to an Event Hub partition.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
 pub struct PartitionPublishingOptions {

--- a/tests/event_hub_connection_live_tests.rs
+++ b/tests/event_hub_connection_live_tests.rs
@@ -2,7 +2,7 @@
 
 use std::cfg;
 
-use azeventhubs::{EventHubConnection, EventHubConnectionOptions, EventHubsTransportType};
+use azeventhubs::{Connection, ConnectionOptions, TransportType};
 use azure_identity::TokenCredentialOptions;
 
 #[macro_use]
@@ -16,8 +16,8 @@ cfg_not_wasm32! {
         common::setup_dotenv();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let options = EventHubConnectionOptions::default();
-        let connection = EventHubConnection::new_from_connection_string(connection_string, None, options)
+        let options = ConnectionOptions::default();
+        let connection = Connection::new_from_connection_string(connection_string, None, options)
             .await
             .unwrap();
         connection.close().await.unwrap();
@@ -30,10 +30,10 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let mut options = EventHubConnectionOptions::default();
-        options.transport_type = EventHubsTransportType::AmqpWebSockets;
+        let mut options = ConnectionOptions::default();
+        options.transport_type = TransportType::AmqpWebSockets;
         let connection =
-            EventHubConnection::new_from_connection_string(connection_string, event_hub_name, options)
+            Connection::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
         connection.close().await.unwrap();
@@ -46,9 +46,9 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let options = EventHubConnectionOptions::default();
+        let options = ConnectionOptions::default();
         let connection =
-            EventHubConnection::new_from_connection_string(connection_string, event_hub_name, options)
+            Connection::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
         connection.close().await.unwrap();
@@ -59,7 +59,7 @@ cfg_not_wasm32! {
         common::setup_dotenv();
         use azeventhubs::authorization::AzureNamedKeyCredential;
 
-        let options = EventHubConnectionOptions::default();
+        let options = ConnectionOptions::default();
 
         let namespace = std::env::var("EVENT_HUBS_NAMESPACE").unwrap();
         let fqn = format!("{}.servicebus.windows.net", namespace);
@@ -69,7 +69,7 @@ cfg_not_wasm32! {
 
         let named_key_credential = AzureNamedKeyCredential::new(key_name, key);
 
-        let connection = EventHubConnection::new_from_named_key_credential(
+        let connection = Connection::new_from_named_key_credential(
             fqn,
             event_hub_name,
             named_key_credential,
@@ -88,10 +88,10 @@ cfg_not_wasm32! {
         let fqn = format!("{}.servicebus.windows.net", namespace);
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
 
-        let options = EventHubConnectionOptions::default();
+        let options = ConnectionOptions::default();
         let credential = DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
 
-        let connection = EventHubConnection::new_from_credential(
+        let connection = Connection::new_from_credential(
             fqn,
             event_hub_name,
             credential,

--- a/tests/event_hub_consumer_client_live_tests.rs
+++ b/tests/event_hub_consumer_client_live_tests.rs
@@ -2,9 +2,9 @@
 
 use azeventhubs::{
     consumer::{
-        EventHubConsumerClient, EventHubConsumerClientOptions, EventPosition, ReadEventOptions,
+        ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
     },
-    EventHubsRetryOptions, MaxRetries,
+    RetryOptions, MaxRetries,
 };
 use futures_util::StreamExt;
 
@@ -20,14 +20,14 @@ cfg_not_wasm32! {
     /// The testing event hub is configured with a retention period of only 1 hour, so this is
     /// necessary to make sure that there are events to read.
     async fn prepare_events_on_eventhubs(num: usize, partition: Option<&str>) {
-        use azeventhubs::producer::{SendEventOptions, EventHubProducerClientOptions, EventHubProducerClient};
+        use azeventhubs::producer::{SendEventOptions, ProducerClientOptions, ProducerClient};
 
         common::setup_dotenv();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, None, options)
+            ProducerClient::new_from_connection_string(connection_string, None, options)
                 .await
                 .unwrap();
 
@@ -54,15 +54,15 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let consumer_group = EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
+        let consumer_group = ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
 
-        let mut retry_options = EventHubsRetryOptions::default();
+        let mut retry_options = RetryOptions::default();
         retry_options.max_retries = MaxRetries::try_from(3).unwrap();
         retry_options.try_timeout = std::time::Duration::from_secs(5);
-        let mut options = EventHubConsumerClientOptions::default();
+        let mut options = ConsumerClientOptions::default();
         options.retry_options = retry_options;
 
-        let mut consumer = EventHubConsumerClient::new_from_connection_string(
+        let mut consumer = ConsumerClient::new_from_connection_string(
             consumer_group,
             connection_string,
             event_hub_name,
@@ -106,15 +106,15 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let consumer_group = EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
+        let consumer_group = ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
 
-        let mut retry_options = EventHubsRetryOptions::default();
+        let mut retry_options = RetryOptions::default();
         retry_options.max_retries = MaxRetries::try_from(3).unwrap();
         retry_options.try_timeout = std::time::Duration::from_secs(5);
-        let mut options = EventHubConsumerClientOptions::default();
+        let mut options = ConsumerClientOptions::default();
         options.retry_options = retry_options;
 
-        let mut consumer = EventHubConsumerClient::new_from_connection_string(
+        let mut consumer = ConsumerClient::new_from_connection_string(
             consumer_group,
             connection_string,
             event_hub_name,
@@ -156,16 +156,16 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let consumer_group = EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
+        let consumer_group = ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
 
-        let mut retry_options = EventHubsRetryOptions::default();
+        let mut retry_options = RetryOptions::default();
         retry_options.max_retries = MaxRetries::try_from(3).unwrap();
         retry_options.try_timeout = std::time::Duration::from_secs(5);
-        let mut options = EventHubConsumerClientOptions::default();
+        let mut options = ConsumerClientOptions::default();
         options.retry_options = retry_options;
 
         let handle = tokio::spawn(async move {
-            let mut consumer = EventHubConsumerClient::new_from_connection_string(
+            let mut consumer = ConsumerClient::new_from_connection_string(
                 consumer_group,
                 connection_string,
                 event_hub_name,

--- a/tests/event_hub_consumer_client_live_tests.rs
+++ b/tests/event_hub_consumer_client_live_tests.rs
@@ -1,10 +1,8 @@
 #![cfg(all(test, feature = "test_e2e"))]
 
 use azeventhubs::{
-    consumer::{
-        ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions,
-    },
-    RetryOptions, MaxRetries,
+    consumer::{ConsumerClient, ConsumerClientOptions, EventPosition, ReadEventOptions},
+    MaxRetries, RetryOptions,
 };
 use futures_util::StreamExt;
 

--- a/tests/event_hub_producer_client_live_tests.rs
+++ b/tests/event_hub_producer_client_live_tests.rs
@@ -1,9 +1,7 @@
 #![cfg(all(test, feature = "test_e2e"))]
 
 use azeventhubs::{
-    producer::{
-        CreateBatchOptions, ProducerClient, ProducerClientOptions, SendEventOptions,
-    },
+    producer::{CreateBatchOptions, ProducerClient, ProducerClientOptions, SendEventOptions},
     Connection, ConnectionOptions,
 };
 use azure_identity::TokenCredentialOptions;

--- a/tests/event_hub_producer_client_live_tests.rs
+++ b/tests/event_hub_producer_client_live_tests.rs
@@ -2,9 +2,9 @@
 
 use azeventhubs::{
     producer::{
-        CreateBatchOptions, EventHubProducerClient, EventHubProducerClientOptions, SendEventOptions,
+        CreateBatchOptions, ProducerClient, ProducerClientOptions, SendEventOptions,
     },
-    EventHubConnection, EventHubConnectionOptions,
+    Connection, ConnectionOptions,
 };
 use azure_identity::TokenCredentialOptions;
 
@@ -19,9 +19,9 @@ cfg_not_wasm32! {
         common::setup_dotenv();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, None, options)
+            ProducerClient::new_from_connection_string(connection_string, None, options)
                 .await
                 .unwrap();
         producer_client.close().await.unwrap();
@@ -38,10 +38,10 @@ cfg_not_wasm32! {
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
         let key_name = std::env::var("EVENT_HUBS_SHARED_ACCESS_KEY_NAME").unwrap();
         let key = std::env::var("EVENT_HUBS_SHARED_ACCESS_KEY").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let named_key_credential = AzureNamedKeyCredential::new(key_name, key);
 
-        let mut producer_client = EventHubProducerClient::new_from_named_key_credential(
+        let mut producer_client = ProducerClient::new_from_named_key_credential(
             fqn,
             event_hub_name,
             named_key_credential,
@@ -64,10 +64,10 @@ cfg_not_wasm32! {
         let namespace = std::env::var("EVENT_HUBS_NAMESPACE").unwrap();
         let fqn = format!("{}.servicebus.windows.net", namespace);
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let default_credential = DefaultAzureCredential::create(TokenCredentialOptions::default()).unwrap();
 
-        let mut producer_client = EventHubProducerClient::new_from_credential(
+        let mut producer_client = ProducerClient::new_from_credential(
             fqn,
             event_hub_name,
             default_credential,
@@ -86,17 +86,17 @@ cfg_not_wasm32! {
         common::setup_dotenv();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let connection_options = EventHubConnectionOptions::default();
+        let connection_options = ConnectionOptions::default();
         let mut connection =
-            EventHubConnection::new_from_connection_string(connection_string, None, connection_options)
+            Connection::new_from_connection_string(connection_string, None, connection_options)
                 .await
                 .unwrap();
 
-        let client_options = EventHubProducerClientOptions::default();
+        let client_options = ProducerClientOptions::default();
         let producer_client_1 =
-            EventHubProducerClient::with_connection(&mut connection, client_options.clone());
+            ProducerClient::with_connection(&mut connection, client_options.clone());
         let producer_client_2 =
-            EventHubProducerClient::with_connection(&mut connection, client_options);
+            ProducerClient::with_connection(&mut connection, client_options);
         producer_client_1.close().await.unwrap();
         producer_client_2.close().await.unwrap();
 
@@ -109,9 +109,9 @@ cfg_not_wasm32! {
         common::setup_dotenv();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, None, options)
+            ProducerClient::new_from_connection_string(connection_string, None, options)
                 .await
                 .unwrap();
 
@@ -127,9 +127,9 @@ cfg_not_wasm32! {
         common::setup_dotenv();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, None, options)
+            ProducerClient::new_from_connection_string(connection_string, None, options)
                 .await
                 .unwrap();
 
@@ -149,9 +149,9 @@ cfg_not_wasm32! {
         // env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace")).init();
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING_WITH_ENTITY_PATH").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, None, options)
+            ProducerClient::new_from_connection_string(connection_string, None, options)
                 .await
                 .unwrap();
 
@@ -176,9 +176,9 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
 
@@ -193,9 +193,9 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
 

--- a/tests/event_hub_producer_client_long_live_tests.rs
+++ b/tests/event_hub_producer_client_long_live_tests.rs
@@ -2,9 +2,7 @@
 
 use std::time::Duration;
 
-use azeventhubs::producer::{
-    ProducerClient, ProducerClientOptions, SendEventOptions,
-};
+use azeventhubs::producer::{ProducerClient, ProducerClientOptions, SendEventOptions};
 
 #[macro_use]
 mod cfg;

--- a/tests/event_hub_producer_client_long_live_tests.rs
+++ b/tests/event_hub_producer_client_long_live_tests.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use azeventhubs::producer::{
-    EventHubProducerClient, EventHubProducerClientOptions, SendEventOptions,
+    ProducerClient, ProducerClientOptions, SendEventOptions,
 };
 
 #[macro_use]
@@ -22,9 +22,9 @@ cfg_not_wasm32! {
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
         let partition_id = "0";
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
 
@@ -56,9 +56,9 @@ cfg_not_wasm32! {
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
         let partition_id = "0";
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
 
@@ -92,9 +92,9 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let options = EventHubProducerClientOptions::default();
+        let options = ProducerClientOptions::default();
         let mut producer_client =
-            EventHubProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
+            ProducerClient::new_from_connection_string(connection_string, event_hub_name, options)
                 .await
                 .unwrap();
         let properties = producer_client.get_event_hub_properties().await.unwrap();

--- a/tests/partition_receiver_live_tests.rs
+++ b/tests/partition_receiver_live_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(all(test, feature = "test_e2e"))]
 
 use azeventhubs::{
-    consumer::{EventHubConsumerClient, EventPosition},
+    consumer::{ConsumerClient, EventPosition},
     primitives::PartitionReceiver,
 };
 
@@ -19,7 +19,7 @@ cfg_not_wasm32! {
 
         let connection_string = std::env::var("EVENT_HUBS_CONNECTION_STRING").unwrap();
         let event_hub_name = std::env::var("EVENT_HUB_NAME").unwrap();
-        let consumer_group = EventHubConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
+        let consumer_group = ConsumerClient::DEFAULT_CONSUMER_GROUP_NAME;
         let partition_id = "0";
 
         let mut receiver = PartitionReceiver::new_from_connection_string(


### PR DESCRIPTION
Remove "EventHub" prefix from most public type names in favour of shorter type names.